### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hal-9001
 
-Hal-9001 is a Go library that offers a number of facilities for creating a bot
+Hal-9001 is a Go library that offers a number of facilities for creating a chat bot
 and its plugins.
 
 # Goals


### PR DESCRIPTION
docs: clarify description of Hal-9001 in README

Updated README to specify "chat bot" instead of "bot" for clearer understanding of Hal-9001's purpose.